### PR TITLE
Get rid of useless pytest-aiohttp dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     long_description=readme.read_text("utf-8"),
     long_description_content_type="text/markdown",
     setup_requires=["pytest-runner"],
-    tests_require=["pytest", "pytest-aiohttp"],
+    tests_require=["pytest"],
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,1 @@
+pytest_plugins = ["aiohttp.pytest_plugin"]

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ python =
 deps =
     -r requirements.txt
     pytest
-    pytest-aiohttp
     pytest-xdist
     pytest-cov
     codecov


### PR DESCRIPTION
 This package is a simple wrapper doing nothing but importing fixtures from aiohttp

See: https://github.com/aio-libs/pytest-aiohttp/tree/master/pytest_aiohttp