### PR TITLE
[Fix] Disable validation should not validate

### DIFF
--- a/aiohttp_swagger3/swagger.py
+++ b/aiohttp_swagger3/swagger.py
@@ -78,7 +78,9 @@ class Swagger(web.UrlDispatcher):
         self.spec_validate = fastjsonschema.compile(
             schema, formats={"uri-reference": r"^\w+:(\/?\/?)[^\s]+\Z|^#(\/\w+)+"}
         )
-        self.spec_validate(self.spec)
+
+        if validate:
+            self.spec_validate(self.spec)
 
         for ui in uis:
             if ui is not None:


### PR DESCRIPTION
I bumped into a situation, where my application does not start because of an invalid swagger definition.
I disabled validation and still ran into the same error.
This is where I discovered, that turning off validation still validates - so here is the fix.

Besides this: the open-api doc that caused this problem is correct according to https://editor.swagger.io.
I also used an online json schema validator, and validated schema and json - also correct.
So I assume there is an issue with fastjsonschema.
I can create a separate issue and attach the schema if you like.
Would be great to have this fix as a workaround in the meantime.
Thanks in advance.
