### PR TITLE
Add regex support in path params

### DIFF
--- a/aiohttp_swagger3/swagger_docs.py
+++ b/aiohttp_swagger3/swagger_docs.py
@@ -13,7 +13,7 @@ from .swagger import ExpectHandler, Swagger
 from .swagger_route import SwaggerRoute, _SwaggerHandler
 from .ui_settings import RapiDocUiSettings, ReDocUiSettings, SwaggerUiSettings
 
-_PATH_VAR_REGEX = re.compile(r"{([_a-zA-Z][_a-zA-Z0-9].+?):.+?}")
+_PATH_VAR_REGEX = re.compile(r"{([_a-zA-Z][_a-zA-Z0-9].+?):.+?}(/|$)")
 
 
 def swagger_doc(path: str) -> Callable:
@@ -113,6 +113,9 @@ class SwaggerDocs(Swagger):
         *_, spec = handler.__doc__.split("---")
         method_spec = yaml.safe_load(spec)
         path = _PATH_VAR_REGEX.sub(r"{\1}", path)
+        if self.spec["paths"].get(path, {}).get(method) is not None:
+            raise Exception(f"{method} {path} already exists")
+
         self.spec["paths"][path][method] = method_spec
         try:
             self.spec_validate(self.spec)

--- a/tests/test_custom_handlers.py
+++ b/tests/test_custom_handlers.py
@@ -78,17 +78,17 @@ async def test_missing_custom_media_type(swagger_docs):
 
     swagger = swagger_docs()
     with pytest.raises(Exception) as exc_info:
-        swagger.add_route("POST", "/r", handler)
+        swagger.add_route("POST", "/r1", handler)
     assert "register handler for custom/handler first" == str(exc_info.value)
 
     swagger.register_media_type_handler("*/handler1", custom_handler)
     with pytest.raises(Exception) as exc_info:
-        swagger.add_route("POST", "/r", handler)
+        swagger.add_route("POST", "/r2", handler)
     assert "missing handler for media type */*" == str(exc_info.value)
 
     swagger.register_media_type_handler("custom/handler1", custom_handler)
     with pytest.raises(Exception) as exc_info:
-        swagger.add_route("POST", "/r", handler)
+        swagger.add_route("POST", "/r3", handler)
     assert "register handler for custom/handler first" == str(exc_info.value)
 
 


### PR DESCRIPTION
There is a possibility in aiohttp library to use regex in path parameters: https://docs.aiohttp.org/en/v3.7.4.post0/web_quickstart.html#variable-resources

But if you use it in swagger routes, there will be a 404 response and the requested url will be `http://0.0.0.0:8080/path/{param_id:\d+}` instead of `http://0.0.0.0:8080/path/1`

This behavior can be fixed by removing regexes from path before adding to OpenAPI specification. So I suggest this fix to enable regex usage in path.

Note, that used regex for parsing path was taken from aiohttp library: 
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/web_urldispatcher.py#L78
https://github.com/aio-libs/aiohttp/blob/master/aiohttp/web_urldispatcher.py#L419