### PR TITLE
Allow aiohttp 3.8.0 as required dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.6.2
+aiohttp>=3.6.2,<3.9.0
 pyyaml>=5.4.0
 attrs>=19.3.0
 fastjsonschema>=2.15.0,<2.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.6.2,<3.8.0
+aiohttp>=3.6.2
 pyyaml>=5.4.0
 attrs>=19.3.0
 fastjsonschema>=2.15.0,<2.16.0


### PR DESCRIPTION
My local tests run fine in this setup.
Maybe we can relax this restriction?