### PR TITLE
Fix missing slash in regex path replacement

### DIFF
--- a/aiohttp_swagger3/swagger_docs.py
+++ b/aiohttp_swagger3/swagger_docs.py
@@ -112,7 +112,7 @@ class SwaggerDocs(Swagger):
             return handler
         *_, spec = handler.__doc__.split("---")
         method_spec = yaml.safe_load(spec)
-        path = _PATH_VAR_REGEX.sub(r"{\1}", path)
+        path = _PATH_VAR_REGEX.sub(r"{\1}\2", path)
         if self.spec["paths"].get(path, {}).get(method) is not None:
             raise Exception(f"{method} {path} already exists")
 

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,5 +1,5 @@
 mypy==0.910
-black==21.10b0
+black==22.3.0
 flake8==4.0.1
 isort==5.10.0
 types-pyyaml>=5.4.0

--- a/tests/test_docs_paths.py
+++ b/tests/test_docs_paths.py
@@ -138,3 +138,4 @@ async def test_path_with_regex(swagger_docs, aiohttp_client):
     resp = await client.get("/r/10/r/11/abc")
     assert resp.status == 200
     assert await resp.json() == {"first_param_id": 10, "second_param_id": 11, "third_param_id": "abc"}
+    assert "/r/{first_param_id}/r/{second_param_id}/{third_param_id}" in swagger.spec["paths"]


### PR DESCRIPTION
When processing paths containing variables with regex validation, `_PATH_VAR_REGEX` captures both the path variable name (`\1`) and a possible trailing slash (`\2`).  But, when substituting the name it does not replace the slash, leading to missing slashes in documented path names.

    swagger.add_get(r'/api/foo/{variable:\d+}/bar', method)

Expected:

    /api/foo/{variable}/bar

Actual:

    /api/foo/{variable}bar

This pull request adds the missing slash back in.
