### PR TITLE
Add support for servers

### DIFF
--- a/aiohttp_swagger3/swagger_docs.py
+++ b/aiohttp_swagger3/swagger_docs.py
@@ -65,6 +65,7 @@ class SwaggerDocs(Swagger):
         *,
         validate: bool = True,
         info: Optional[SwaggerInfo] = None,
+        servers: Optional[Dict] = None,
         request_key: str = "data",
         title: Optional[str] = None,
         version: Optional[str] = None,
@@ -115,6 +116,9 @@ class SwaggerDocs(Swagger):
         if security:
             with open(security) as f:
                 spec.update(yaml.safe_load(f))
+
+        if servers:
+            spec["servers"] = servers
 
         super().__init__(
             app,


### PR DESCRIPTION
Hi

This closes this issue that I made https://github.com/hh-h/aiohttp-swagger3/issues/106

You can now pass the servers object as the swagger [docs](https://swagger.io/docs/specification/api-host-and-base-path/) suggests. This can be used to set the endpoint that the swagger frontend hits

```py
s = SwaggerDocs(
    app,
    swagger_ui_settings=SwaggerUiSettings(path="/docs"),
    info=SwaggerInfo(
        title="Admin API",
        version="1.0.0",
    ),
    servers=[{"url": "/admin"}],
)
```