### PR TITLE
Use request.content_type instead of cgi.parse_header

### DIFF
--- a/aiohttp_swagger3/swagger_route.py
+++ b/aiohttp_swagger3/swagger_route.py
@@ -1,4 +1,3 @@
-import cgi
 import json
 from types import FunctionType
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple, cast
@@ -166,7 +165,7 @@ class SwaggerRoute:
                     if next(iter(self.bp.values())).required:
                         errors[REQUEST_BODY_NAME] = "is required"
                 else:
-                    media_type, _ = cgi.parse_header(request.headers["Content-Type"])
+                    media_type = request.content_type
                     if media_type not in self.bp:
                         errors[REQUEST_BODY_NAME] = f"no handler for {media_type}"
                     else:


### PR DESCRIPTION
cgi is deprecated as of PEP 594 in python 3.11, and set to be removed in 3.13

https://peps.python.org/pep-0594/#cgi

The pep recommends using `email.message.Message`, but aiohttp has `request.content_type`[doc](https://docs.aiohttp.org/en/stable/web_reference.html?highlight=content_type#aiohttp.web.BaseRequest.content_type) which makes far more sense for us.
