### PR TITLE
Fix View methods in python3.11. Fixes #108

### DIFF
--- a/aiohttp_swagger3/swagger.py
+++ b/aiohttp_swagger3/swagger.py
@@ -132,14 +132,6 @@ class Swagger(web.UrlDispatcher):
 
         self._app[ui_index_html] = ui_template.substitute({"settings": json.dumps(ui_settings.to_settings())})
 
-    async def _handle_swagger_call(self, route: "SwaggerRoute", request: web.Request) -> web.StreamResponse:
-        kwargs = await route.parse(request)
-        return await route.handler(**kwargs)
-
-    async def _handle_swagger_method_call(self, view: web.View, route: "SwaggerRoute") -> web.StreamResponse:
-        kwargs = await route.parse(view.request)
-        return await route.handler(view, **kwargs)
-
     def add_head(self, path: str, handler: WebHandler, **kwargs: Any) -> web.AbstractRoute:
         return self.add_route(hdrs.METH_HEAD, path, handler, **kwargs)
 
@@ -235,3 +227,13 @@ class Swagger(web.UrlDispatcher):
                 raise Exception(f"register handler for {media_type} first")
             return self.handlers[typ]["*"]
         return self.handlers[typ][subtype]
+
+
+async def _handle_swagger_call(route: "SwaggerRoute", request: web.Request) -> web.StreamResponse:
+    kwargs = await route.parse(request)
+    return await route.handler(**kwargs)
+
+
+async def _handle_swagger_method_call(view: web.View, route: "SwaggerRoute") -> web.StreamResponse:
+    kwargs = await route.parse(view.request)
+    return await route.handler(view, **kwargs)

--- a/aiohttp_swagger3/swagger_docs.py
+++ b/aiohttp_swagger3/swagger_docs.py
@@ -10,7 +10,7 @@ from aiohttp import hdrs, web
 from aiohttp.abc import AbstractView
 
 from .routes import _SWAGGER_SPECIFICATION
-from .swagger import ExpectHandler, Swagger
+from .swagger import ExpectHandler, Swagger, _handle_swagger_call, _handle_swagger_method_call
 from .swagger_info import SwaggerInfo
 from .swagger_route import SwaggerRoute, _SwaggerHandler
 from .ui_settings import RapiDocUiSettings, ReDocUiSettings, SwaggerUiSettings
@@ -155,8 +155,8 @@ class SwaggerDocs(Swagger):
             return handler
         route = SwaggerRoute(method, path, handler, swagger=self)
         if is_method:
-            return functools.partialmethod(self._handle_swagger_method_call, route)  # type: ignore
-        return functools.partial(self._handle_swagger_call, route)
+            return functools.partialmethod(_handle_swagger_method_call, route)  # type: ignore
+        return functools.partial(_handle_swagger_call, route)
 
     def add_route(
         self,

--- a/aiohttp_swagger3/swagger_file.py
+++ b/aiohttp_swagger3/swagger_file.py
@@ -6,7 +6,7 @@ from aiohttp import hdrs, web
 from aiohttp.abc import AbstractView
 
 from .routes import _SWAGGER_SPECIFICATION
-from .swagger import ExpectHandler, Swagger
+from .swagger import ExpectHandler, Swagger, _handle_swagger_call, _handle_swagger_method_call
 from .swagger_route import SwaggerRoute, _SwaggerHandler
 from .ui_settings import RapiDocUiSettings, ReDocUiSettings, SwaggerUiSettings
 
@@ -80,12 +80,12 @@ class SwaggerFile(Swagger):
                     setattr(
                         handler,
                         meth,
-                        functools.partialmethod(self._handle_swagger_method_call, route),
+                        functools.partialmethod(_handle_swagger_method_call, route),
                     )
             else:
                 method_lower = method.lower()
                 if method_lower in self.spec["paths"][path]:
                     route = SwaggerRoute(method_lower, path, handler, swagger=self)
-                    handler = functools.partial(self._handle_swagger_call, route)
+                    handler = functools.partial(_handle_swagger_call, route)
 
         return self._app.router.add_route(method, path, handler, name=name, expect_handler=expect_handler)


### PR DESCRIPTION
I have logged a [bug](https://github.com/python/cpython/issues/99152) for this in CPython, but I think we should fix it with this change.

I don't see a reason that `_handle_swagger_call` and `_handle_swagger_method_call` are methods of `Swagger` other than to allow for overrides in subclasses, but given that they are marked as private, no users of this libary should be doing this.

