### PR TITLE
Fix tox.ini when used with tox 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
 install:
   - pip install -U pip setuptools
   - pip install -r requirements.txt
-  - pip install tox-travis codecov
+  - pip install -U "tox < 4" tox-travis codecov
 script:
   - tox
 after_success:

--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ deps =
 commands =
     pytest --cov=aiohttp_swagger3 --cov-report=term-missing tests/
     codecov -e TOXENV
-passenv = TOXENV CI TRAVIS TRAVIS_*
+passenv = TOXENV,CI,TRAVIS,TRAVIS_*
 
 [testenv:check]
 deps =


### PR DESCRIPTION
This fixes the following error when testing with tox 4.0 :

> failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'TOXENV CI TRAVIS TRAVIS_*

Tested change with tox 4.0.11 and tox 3.27.1.