### PR TITLE
Replace GPL-licensed strict_rfc3339 for MIT-licensed rfc3339-validator

### DIFF
--- a/aiohttp_swagger3/string_formats.py
+++ b/aiohttp_swagger3/string_formats.py
@@ -3,7 +3,7 @@ import ipaddress
 import re
 import uuid
 
-import strict_rfc3339
+from rfc3339_validator import validate_rfc3339
 
 from .exceptions import ValidatorError
 
@@ -19,12 +19,12 @@ def sf_uuid_validator(value: str) -> None:
 
 
 def sf_date_validator(value: str) -> None:
-    if not strict_rfc3339.validate_rfc3339(f"{value}T00:00:00Z"):
+    if not validate_rfc3339(f"{value}T00:00:00Z"):
         raise ValidatorError("value should be date format")
 
 
 def sf_date_time_validator(value: str) -> None:
-    if not strict_rfc3339.validate_rfc3339(value):
+    if not validate_rfc3339(value):
         raise ValidatorError("value should be datetime format")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ aiohttp>=3.6.2,<3.9.0
 pyyaml>=5.4.0
 attrs>=19.3.0
 fastjsonschema>=2.15.0,<2.16.0
-strict_rfc3339>=0.7
+rfc3339-validator>=0.1.4,<1.0


### PR DESCRIPTION
strict_rfc3339 is apparently dead and there is a problem in using GPL-dependency in non-GPL ecosystem.