### PR TITLE
Allow aiohttp 3.10

### DIFF
--- a/aiohttp_swagger3/__init__.py
+++ b/aiohttp_swagger3/__init__.py
@@ -12,7 +12,7 @@ __all__ = (
     "ValidatorError",
     "__version__",
 )
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 __author__ = "Valetov Konstantin"
 
 from .exceptions import ValidatorError

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2023, Konstantin Valetov'
 author = 'Konstantin Valetov'
 
 # The full version, including alpha/beta/rc tags
-release = '0.8.0'
+release = '0.9.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.8.0,<3.10.0
+aiohttp>=3.8.0,<3.11.0
 pyyaml>=5.4.0
 attrs>=19.3.0
 fastjsonschema>=2.15.0,<2.20.0


### PR DESCRIPTION
The current release of this library is blocking us from moving to the latest aiohttp.
Please publish an update that allows 3.10.