### PR TITLE
chore: allow aiohttp 3.11 and 3.x

### DIFF
--- a/aiohttp_swagger3/__init__.py
+++ b/aiohttp_swagger3/__init__.py
@@ -12,7 +12,7 @@ __all__ = (
     "ValidatorError",
     "__version__",
 )
-__version__ = "0.9.0"
+__version__ = "0.10.0"
 __author__ = "Valetov Konstantin"
 
 from .exceptions import ValidatorError

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ copyright = '2023, Konstantin Valetov'
 author = 'Konstantin Valetov'
 
 # The full version, including alpha/beta/rc tags
-release = '0.9.0'
+release = '0.10.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp>=3.8.0,<3.11.0
+aiohttp>=3.8.0,<4
 pyyaml>=5.4.0
 attrs>=19.3.0
 fastjsonschema>=2.15.0,<2.20.0

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Development Status :: 4 - Beta",
         "Operating System :: POSIX",
         "Operating System :: MacOS :: MacOS X",


### PR DESCRIPTION
This PR pins aiohttp max version to <4, so all non-breaking aiohttp 3.x updates are supported.
